### PR TITLE
Фиксы от Альбины.

### DIFF
--- a/web/src/pages/articles/articlePage/article/music.tsx
+++ b/web/src/pages/articles/articlePage/article/music.tsx
@@ -9,10 +9,10 @@ export function Music() {
       third planet, Samosad bend, ОРК и КО, Vespero, Фёдор Ларюшкин и десятки других групп и музыкантов.
     </div>
     <Link style={{marginBottom: 8}} goTo={['activities','location',location._id]}>расписание муз сцена</Link>
-    <div>Легендарная Бессонничная Карусель снова будет крутиться, звучать, сиять и дымить!</div>
+    {/* <div>Легендарная Бессонничная Карусель снова будет крутиться, звучать, сиять и дымить!</div>
     <Link goTo="/map" query={{name: 'заря'}}>к заре</Link>
     <ButtonsBar at="bottom">
       <Button type="blue" goTo={['map', {name: 'музыкальная'}]} class="w-full">к муз. сцене</Button>
-    </ButtonsBar>
+    </ButtonsBar> */}
   </PageLayout>
 }


### PR DESCRIPTION
Удалено упоминание Бессоничной Карусели со страницы музыкальных статей (Music)