### PR TITLE
feat/intronet-front-0003: Добавил поиск по группам, перенес "лупу" по…

### DIFF
--- a/server/typings.d.ts
+++ b/server/typings.d.ts
@@ -7,6 +7,7 @@ type InsomniaLocation = {
   name: string;
   description: string;
   directionId: string;
+  groupLink?: string;
   figure: GeoFigure;
   tags: string[];
   work_tags: string[];

--- a/web/index.d.ts
+++ b/web/index.d.ts
@@ -48,6 +48,8 @@ type InsomniaLocation = {
   name: string;
   description: string;
   directionId: string;
+  /** Ключ группы для URL ?direction= и поиска «все точки категории» (колонка «Ссылка на группу»). */
+  groupLink?: string;
   figure: GeoFigure;
   tags: string[];
   work_tags: string[];

--- a/web/src/components/highlight.tsx
+++ b/web/src/components/highlight.tsx
@@ -1,8 +1,8 @@
-import {searchDataValidator} from "@stores/search.store";
+import { searchDataValidator } from "@helpers/search-normalize";
 
 export function highlight(text: string, query: string | undefined) {
   text = searchDataValidator(text);
-  query = searchDataValidator(query)?.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  query = searchDataValidator(query).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   if (!query || !text) return text;
   if (!text.toLowerCase().includes(query.toLowerCase())) {
     return text;

--- a/web/src/helpers/search-normalize.ts
+++ b/web/src/helpers/search-normalize.ts
@@ -1,0 +1,17 @@
+/** Нормализация строки для поиска (ё/е и т.д.) — общая для стора локаций и поиска. Всегда возвращает строку. */
+export function searchDataValidator(data: string | null | undefined): string {
+  if (data == null || data === "") {
+    return "";
+  }
+  return data.replace(/[е|ё]/g, "е");
+}
+
+/** decodeURIComponent без URIError при битом `%` в query (и защита от null). */
+export function safeDecodeURIComponent(value: string | null | undefined): string {
+  if (value == null || value === "") return "";
+  try {
+    return decodeURIComponent(value).trim();
+  } catch {
+    return value.trim();
+  }
+}

--- a/web/src/pages/map/map-page.module.css
+++ b/web/src/pages/map/map-page.module.css
@@ -4,27 +4,26 @@
   right: 3px;
   z-index: 1;
 }
-.full{
+
+.full {
   margin: 0;
   padding: 0;
 }
+
 .header {
   position: fixed;
-  width: calc(100% - 32px);
   top: 44px;
-  left: 50%;
-  transform: translateX(-50%);
+  right: 16px;
+  left: auto;
+  transform: none;
   display: flex;
   align-items: center;
-  gap: 16px;
-  z-index: 1;
+  justify-content: flex-end;
+  z-index: 5;
 }
-.header > svg {
+
+.header>svg {
   flex: 0 0 auto;
-}
-.header > div {
-  min-width: 0;
-  flex: 1;
 }
 
 .favoritesIcon {
@@ -85,7 +84,7 @@
   overflow-x: scroll;
 }
 
-:global(button).mapButton{
+:global(button).mapButton {
   width: 56px;
   height: 64px;
 }
@@ -103,7 +102,82 @@
   border: none;
 }
 
-.editBar{
+.mapBottomBar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 80px;
+  z-index: 4;
+  padding: 0 10px 8px;
+  padding-bottom: max(8px, env(safe-area-inset-bottom, 0px));
+  box-sizing: border-box;
+  max-width: 440px;
+  margin: 0 auto;
+  pointer-events: none;
+}
+
+.mapBottomBarInner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  pointer-events: auto;
+}
+
+.searchFab {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: #2a9d8f;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
+}
+
+.searchFab:focus-visible {
+  outline: 2px solid var(--vivid);
+  outline-offset: 2px;
+}
+
+.chipsScroll {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  overflow-x: auto;
+  flex: 1;
+  min-width: 0;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.chipsScroll::-webkit-scrollbar {
+  display: none;
+}
+
+.mapChip {
+  flex-shrink: 0;
+  border: none;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  white-space: nowrap;
+  background: #4a3728;
+  color: var(--white);
+}
+
+.mapChipActive {
+  background: #6bbdb0;
+  color: var(--white);
+}
+
+.editBar {
   position: absolute;
   top: 0;
   padding: 16px 0 8px 0;

--- a/web/src/pages/map/map-page.tsx
+++ b/web/src/pages/map/map-page.tsx
@@ -12,9 +12,19 @@ import { useLocationsRouter } from "./hooks/useLocationsRouter";
 import { LocationSearch } from "./search/location-search";
 import { Location } from "./location/location";
 import { LocationMenu } from "./location/location-menu";
-import { SearchInput } from "@components/input/search-input";
-import { goTo } from "../routing";
+import { goTo, routerCell } from "../routing";
 import { useRef } from "preact/hooks";
+import { searchStore } from "@stores/search.store";
+import {
+  searchDataValidator,
+  safeDecodeURIComponent,
+} from "@helpers/search-normalize";
+
+function isSameMapFilterChip(active: string, label: string) {
+  const a = searchDataValidator(active).toLowerCase();
+  const b = searchDataValidator(label).toLowerCase();
+  return !!a && a === b;
+}
 
 /**
  * Страница карты с роутингом по локациям и нижним листом.
@@ -47,11 +57,6 @@ export function MapPageWithRouting() {
       hideSearchDeps={[router.locationId]}
     >
       <div className={styles.header}>
-        <SearchInput
-          placeholder="Площадка"
-          style={{ background: "var(--white)" }}
-          onFocus={() => router.goTo([router.route[0], "search"])}
-        />
         <SvgIcon
           id="#bookmark"
           style={{
@@ -122,6 +127,7 @@ export function MapPageWithRouting() {
                 <SvgIcon id="#x" />
               </Button>
             </ButtonsBar>
+            <MapSearchBottomBar />
           </>
         )}
         <Sheet
@@ -144,6 +150,73 @@ export function MapPageWithRouting() {
         />
       </div>
     </PageLayout>
+  );
+}
+
+/** Нижняя панель: лупа открывает поиск, чипы — переход по `groupLink` (`?direction=`). */
+function MapSearchBottomBar() {
+  const router = useLocationsRouter();
+  const isEditing = useCell(() => locationsStore.isEdit);
+  const activeDirection = useCell(() =>
+    safeDecodeURIComponent(routerCell.get().query.direction)
+  );
+  const groupChips = useCell(() => {
+    const counts = new Map<string, number>();
+    for (const loc of locationsStore.Locations) {
+      const g = loc.groupLink?.trim();
+      if (!g) continue;
+      counts.set(g, (counts.get(g) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 24)
+      .map(([gl]) => gl);
+  });
+
+  if (isEditing) return null;
+  if (["search", "add", "edit"].includes(router.locationId ?? "")) return null;
+
+  return (
+    <div className={styles.mapBottomBar}>
+      <div className={styles.mapBottomBarInner}>
+        <button
+          type="button"
+          className={styles.searchFab}
+          aria-label="Поиск по карте"
+          onClick={() => {
+            searchStore.query.set("");
+            router.goTo(["map", "search"]);
+          }}
+        >
+          <SvgIcon
+            id="#search"
+            stroke-width={1.6}
+            style={{ color: "var(--white)" }}
+            size={18}
+          />
+        </button>
+        <div className={styles.chipsScroll}>
+          {groupChips.map((label) => (
+            <button
+              key={label}
+              type="button"
+              className={
+                isSameMapFilterChip(activeDirection, label)
+                  ? `${styles.mapChip} ${styles.mapChipActive}`
+                  : styles.mapChip
+              }
+              onClick={() =>
+                isSameMapFilterChip(activeDirection, label)
+                  ? goTo(["map"], {})
+                  : goTo(["map"], { direction: label })
+              }
+            >
+              {label.length > 22 ? `${label.slice(0, 20)}…` : label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/web/src/pages/map/search/location-search.module.css
+++ b/web/src/pages/map/search/location-search.module.css
@@ -1,0 +1,38 @@
+.groupRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--radius, 12px);
+  background: var(--cold-white, #f5f5f5);
+  border: 1px solid var(--el-blue, #b8d4e3);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  box-sizing: border-box;
+  font: inherit;
+  color: var(--ins-night);
+}
+
+.groupRowTitle {
+  font-weight: 600;
+}
+
+.groupRowHint {
+  font-size: 13px;
+  opacity: 0.75;
+  margin-top: 4px;
+}
+
+.groupRowCount {
+  flex-shrink: 0;
+  font-size: 14px;
+  opacity: 0.8;
+}
+
+.groupsBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/web/src/pages/map/search/location-search.tsx
+++ b/web/src/pages/map/search/location-search.tsx
@@ -5,15 +5,26 @@ import { LocationList } from "../location/location-list";
 import { searchStore } from "@stores/search.store";
 import { useEffect } from "preact/hooks";
 import { PageHeader } from "@components/PageHeader/PageHeader";
+import { goTo } from "../../routing";
+import searchStyles from "./location-search.module.css";
 
 export const LocationSearch = () => {
   const query = useCell(searchStore.query);
   const locations = useCell(searchStore.filteredLocations);
+  const groups = useCell(searchStore.matchedLocationGroups);
   useEffect(() => () => searchStore.query.set(""), []);
+
+  const openGroup = (groupLink: string) => {
+    goTo(["map"], { direction: groupLink });
+    searchStore.query.set("");
+  };
+
+  const showEmptyPlug =
+    groups.length === 0 && locations.length === 0 && query.trim().length > 0;
 
   return (
     <div flex column gap={5} className="h-full">
-      <PageHeader titleH1={'поиск'} withCloseButton/>
+      <PageHeader titleH1={"поиск"} withCloseButton />
 
       <Input
         autofocus
@@ -22,14 +33,37 @@ export const LocationSearch = () => {
         onInput={searchStore.onInput}
       />
 
+      {groups.length > 0 && (
+        <div className={searchStyles.groupsBlock}>
+          {groups.map((g) => (
+            <button
+              key={g.groupLink}
+              type="button"
+              className={searchStyles.groupRow}
+              onClick={() => openGroup(g.groupLink)}
+            >
+              <span>
+                <div className={searchStyles.groupRowTitle}>
+                  Все «{g.groupLink}» на карте
+                </div>
+                <div className={searchStyles.groupRowHint}>
+                  Показать все точки категории
+                </div>
+              </span>
+              <span className={searchStyles.groupRowCount}>{g.count}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
       {locations.length > 0 ? (
         <LocationList locations={locations} searchQuery={query} />
-      ) : (
+      ) : showEmptyPlug ? (
         <SearchPlug
           title={"Ничего не найдено"}
           text={"Попробуйте найти площадку по названию"}
         />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/web/src/stores/locations.store.ts
+++ b/web/src/stores/locations.store.ts
@@ -10,6 +10,10 @@ import { bookmarksStore } from "./bookmarks.store";
 import { bind, distinct, Fn, orderBy } from "@cmmn/core";
 import { LocalObservableDB } from "@stores/localObservableDB";
 import { authStore } from "@stores/auth.store";
+import {
+  searchDataValidator,
+  safeDecodeURIComponent,
+} from "../helpers/search-normalize";
 
 class LocationsStore {
   @cell db = new ObservableDB<InsomniaLocation>("locations");
@@ -38,14 +42,18 @@ class LocationsStore {
       return [this.Locations.find((x) => x._id === router.route[1])].filter(
         (x) => x
       );
-    if (router.query.direction)
-      return this.findByDirection(decodeURIComponent(router.query.direction));
+    if (router.query.direction) {
+      const dir = safeDecodeURIComponent(router.query.direction);
+      const byGroup = this.findByGroupLink(dir);
+      if (byGroup.length) return byGroup;
+      return this.findByDirection(dir);
+    }
     if (router.query.name)
-      return [this.findByName(decodeURIComponent(router.query.name))].filter(
+      return [this.findByName(safeDecodeURIComponent(router.query.name))].filter(
         (x) => x
       );
     if (router.query.tag)
-      return this.findByTag(decodeURIComponent(router.query.tag));
+      return this.findByTag(safeDecodeURIComponent(router.query.tag));
     return [];
   }
 
@@ -63,8 +71,23 @@ class LocationsStore {
     );
   }
   findByDirection(s: string) {
+    const q = searchDataValidator(s).toLowerCase();
+    if (!q) return [];
     return this.Locations.filter(
-      (x) => x.directionId?.toLowerCase() == s.toLowerCase()
+      (x) =>
+        !!x.directionId &&
+        searchDataValidator(x.directionId).toLowerCase() === q
+    );
+  }
+
+  /** Все локации с тем же `groupLink`, что и в query (колонка «Ссылка на группу»). */
+  findByGroupLink(s: string) {
+    const q = searchDataValidator(s.trim()).toLowerCase();
+    if (!q) return [];
+    return this.Locations.filter(
+      (x) =>
+        !!x.groupLink?.trim() &&
+        searchDataValidator(x.groupLink.trim()).toLowerCase() === q
     );
   }
   public setSelectedId(id: string | null) {

--- a/web/src/stores/search.store.ts
+++ b/web/src/stores/search.store.ts
@@ -4,7 +4,10 @@ import { bind } from "@cmmn/core";
 import { ChangeEvent } from "preact/compat";
 import { locationsStore } from "@stores/locations.store";
 import { activitiesStore } from "@stores/activities";
-import { notesStore } from './notes'
+import { notesStore } from "./notes";
+import { searchDataValidator } from "../helpers/search-normalize";
+
+export { searchDataValidator } from "../helpers/search-normalize";
 
 class SearchStore {
   public query = new Cell<string>("");
@@ -24,9 +27,34 @@ class SearchStore {
     return moviesStore.Movies.filter(movieChecker(this.queryRegex));
   });
 
+  /** Группы локаций по `groupLink`, у которых сам ключ совпал с запросом (приоритет в UI поиска). */
+  public matchedLocationGroups = new Cell(() => {
+    if (!this.queryRegex) return [] as { groupLink: string; count: number }[];
+    const counts = new Map<string, number>();
+    for (const loc of locationsStore.Locations) {
+      const gl = loc.groupLink?.trim();
+      if (!gl) continue;
+      counts.set(gl, (counts.get(gl) ?? 0) + 1);
+    }
+    const out: { groupLink: string; count: number }[] = [];
+    for (const [groupLink, count] of counts) {
+      if (this.queryRegex.test(searchDataValidator(groupLink))) {
+        out.push({ groupLink, count });
+      }
+    }
+    return out.sort((a, b) => b.count - a.count);
+  });
+
   public filteredLocations = new Cell(() => {
     if (!this.queryRegex) return [];
-    return locationsStore.Locations.filter(locationChecker(this.queryRegex));
+    const promoted = new Set(
+      this.matchedLocationGroups.get().map((g) => g.groupLink)
+    );
+    return locationsStore.Locations.filter((loc) => {
+      const gl = loc.groupLink?.trim();
+      if (gl && promoted.has(gl)) return false;
+      return locationChecker(this.queryRegex)(loc);
+    });
   });
 
   public filteredActivities = new Cell(() => {
@@ -53,8 +81,7 @@ const movieChecker: Checker<MovieInfo> = (regex) => (movie) =>
 
 const locationChecker: Checker<InsomniaLocation> = (regex) => (location) =>
   regex.test(searchDataValidator(location.name)) ||
-  location?.work_tags?.some((x) => regex.test(searchDataValidator(x))) ||
-  regex.test(searchDataValidator(location.directionId));
+  !!location?.work_tags?.some((x) => regex.test(searchDataValidator(x)));
 
 const activityChecker: Checker<Activity> = (regex) => (activity) =>
   regex.test(searchDataValidator(activity.title)) ||
@@ -63,13 +90,5 @@ const activityChecker: Checker<Activity> = (regex) => (activity) =>
 const noteChecker: Checker<INote> = (regex) => (note) =>
   regex.test(searchDataValidator(note.title)) ||
   regex.test(searchDataValidator(note.text));
-
-export const searchDataValidator = (data: string) => {
-  if (!data) {
-    return data;
-  }
-
-  return data.replace(/[е|ё]/g, "е");
-};
 
 export type Checker<T> = (regex: RegExp) => (item: T) => boolean;


### PR DESCRIPTION
Важно по данным: чтобы «туалет» давал одну группу, в таблице у всех туалетов должно быть одинаковое значение «Ссылка на группу» (например Туалет), совпадающее с тем, что пользователь вводит / с чем совпадает regex. Если groupLink пустой, сработает только fallback по directionId в URL и поиск по именам (длинный список возможен).